### PR TITLE
fix: update active highlight state for docs site header H5/Taro tab

### DIFF
--- a/src/sites/doc/components/DocHeader.vue
+++ b/src/sites/doc/components/DocHeader.vue
@@ -4,22 +4,31 @@
       <a class="logo-link" href="#" @click="toHome"></a>
     </div>
     <div class="tabs">
-      <div class="tab-item" @click="switchTo('h5')">h5</div>
-      <div class="tab-item" @click="switchTo('taro')">taro</div>
+      <div
+        v-for="type in tabs"
+        :key="type"
+        class="tab-item"
+        :class="{ cur: activeTab === type }"
+        @click="router.push(route.path.replace(/^\/(h5|taro)\//, `/${type}/`))"
+      >
+        {{ type }}
+      </div>
     </div>
   </div>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { RefData } from '@/sites/assets/util/ref'
+const route = useRoute()
+const router = useRouter()
+const tabs = ['h5', 'taro'] as const
+// route.path 是响应式的，路由切换时自动更新选中态
+const activeTab = computed<'h5' | 'taro'>(() => {
+  return route.path.startsWith('/taro/') ? 'taro' : 'h5'
+})
 const toHome = () => {
   RefData.getInstance().currentRoute.value = '/'
-}
-const switchTo = (type: 'h5' | 'taro') => {
-  if (type === 'h5') {
-    location.href = location.href.replace('taro', 'h5')
-  } else {
-    location.href = location.href.replace('h5', 'taro')
-  }
 }
 </script>
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/jd-opensource/nutui/issues/1671
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
fix #3329
Fix the docs site header H5/Taro tab, make the tab active highlight state update synchronously when switching. Only modify the documentation page code, no impact on component library source code.

**这个 PR 是什么类型?** (至少选择一个)

- [ ] feat: 新特性提交
- [x] fix: bug 修复
- [ ] docs: 文档改进
- [ ] style: 组件样式/交互改进
- [ ] type: 类型定义更新
- [ ] perf: 性能、包体积优化
- [ ] refactor: 代码重构、代码风格优化
- [ ] test: 测试用例
- [ ] chore(deps): 依赖升级
- [ ] chore(demo): 演示代码改进
- [ ] chore(locale): 国际化改进
- [ ] chore: 其他改动（是关于什么的改动？）

**这个 PR 涉及以下平台:**

- [x] NutUI H5 @nutui/nutui
- [ ] NutUI Taro @nutui/nutui-taro

**这个 PR 是否已自测:**

- [ ] 自测 Vite 脚手架使用 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/vite)
- [ ] 自测 Taro 脚手架使用小程序 & Taro-H5 [测试仓库](https://github.com/jd-opensource/nutui-demo/tree/dev/taro)
